### PR TITLE
Sort integers properly before verifying match

### DIFF
--- a/ffa.js
+++ b/ffa.js
@@ -217,9 +217,13 @@ FFA.prototype._safe = function (match) {
   });
 };
 
+var compareInt = function(a, b) {
+  return a - b;
+}
+
 FFA.prototype._verify = function (match, score) {
   var adv = this.advs[match.id.r - 1] || 0;
-  var sortedScore = score.slice().sort().reverse();
+  var sortedScore = score.slice().sort(compareInt).reverse();
   if (adv > 0 && sortedScore[adv] === sortedScore[adv - 1]) {
     return 'scores must unambiguous decide who advances';
   }

--- a/test/ffa.unscorable.test.js
+++ b/test/ffa.unscorable.test.js
@@ -78,3 +78,14 @@ test('unambiguous', function *(t) {
     'some identical scores but advancers are unambiguous'
   );
 });
+
+test('unambiguous with large numbers', function *(t) {
+  var ffa = new FFA(24, { sizes: [6, 6, 6, 3], advancers: [3, 3, 3] });
+  var match = ffa.findMatch({s: 1, r: 1, m: 1})
+
+  t.eq(
+    ffa.unscorable(match.id, [13, 13, 11, 9, 1, 99]),
+    null,
+    'some identical scores but advancers are unambiguous'
+  );
+});


### PR DESCRIPTION
Oopsie.

Usually I use `lodash` or similar, but since it wasn't already a dependency, I opted to shoot myself in the leg instead. For clarity, `Array.prototype.sort()` uses alphabetical sorting by default, even on numbers.

This is a quick fix that I had to do for our tournament tomorrow. 😅